### PR TITLE
Stubs file extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # PHP msgpack stubs
+
+This package provides stubs for [msgpack](https://github.com/msgpack/msgpack-php) PHP extension.
+
+[MessagePack](https://msgpack.org/) is a binary-based efficient object serialization library.
+It enables to exchange structured objects between many languages like JSON.
+But unlike JSON, it is very fast and small.
+
+## Installation
+`composer require --dev gilek/php-msgpack-stubs`

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,16 @@
 {
     "name": "gilek/php-msgpack-stubs",
+    "description": "This package provides stubs for msgpack PHP extension.",
     "require": {},
     "license": "MIT",
     "authors": [
       {
         "name": "Maciej Kłak",
         "email": "klak.maciej@gmail.com"
+      },
+      {
+        "name": "Denis Koshechkin",
+        "email": "bushikot@gmail.com"
       }
     ]
 }

--- a/msgpack.php
+++ b/msgpack.php
@@ -1,12 +1,79 @@
 <?php
-/**
- * @param mixed $data
- * @return mixed
- */
-function msgpack_pack($data){}
 
 /**
- * @param string $data
+ * @param mixed $value
  * @return string
  */
-function msgpack_unpack($data){}
+function msgpack_pack($value) {}
+
+/**
+ * @param string $str
+ * @return object|string $object 
+ * @return mixed
+ */
+function msgpack_unpack($str, $object = null) {}
+
+class MessagePack {
+    const OPT_PHPONLY = -1001;
+
+    /**
+     * @param bool $opt
+     */
+    public function __construct($opt = null) {}
+
+    /**
+     * @param int $option
+     * @param mixed $value
+     */
+    public function setOption($option, $value) {}
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function pack($value) {}
+
+    /**
+     * @param string $str
+     * @return object|string $object 
+     */
+    public function unpack($str, $object = null) {}
+
+    /**
+     * @return MessagePackUnpacker
+     */
+    public function unpacker() {}
+}
+
+class MessagePackUnpacker {
+
+    /**
+     * @param bool $opt
+     */
+    public function __construct($opt = null) {}
+
+    /**
+     * @param int $option
+     * @param mixed $value
+     */
+    public function setOption($option, $value) {}
+
+    /**
+     * @param string $str
+     */
+    public function feed($str) {}
+
+    /**
+     * @param string $str
+     * @param int $offset
+     */
+    public function execute($str, $offset) {} 
+
+    /**
+     * @param object|string $object
+     * @return mixed
+     */
+    public function data($object = null) {}
+
+    public function reset() {}
+}


### PR DESCRIPTION
Hi @gilek!
Your msgpack stubs package is most popular(and probably only one) on packagist.org, so I decided to extend it instead of creating new one. You might be surprised by all of this things added by me, because they are not mentioned in examples on readme page of official extension's repo. Still, you can easily find this classes in extension tests files, and also in this extended readme of some active PR: [link](https://github.com/msgpack/msgpack-php/blob/ad1c3b60fb7a996afae187e0861d7bfd869f8ccf/README.md).

In short - `MessagePackUnpacker` provides an ability to parse streams.

Hope you like that. Thanks in advance!