### PR TITLE
Reduce msgpack_pack @return to be a single entry

### DIFF
--- a/msgpack.php
+++ b/msgpack.php
@@ -8,8 +8,7 @@ function msgpack_pack ($value) {}
 
 /**
  * @param string $str
- * @return object|string $object
- * @return mixed
+ * @return object|string|mixed $object
  */
 function msgpack_unpack ($str, $object = null) {}
 


### PR DESCRIPTION
Thanks for writing this, very useful :+1: 

The `msgpack_unpack` function currently has the `@return` split between two separate lines. This [isn't valid](http://docs.phpdoc.org/references/phpdoc/tags/return.html) according to the PHPDocs and causes PHPStorm to complain when you try to use msgpack_unpack into something typehinted as an array.

I've moved it all onto the one line and it seems to work fine
